### PR TITLE
Refactor.makara builder2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v1.1.8-alpha.1
+### v1.1.8-alpha.2
 
 * REFACTOR: to use makara-builder@2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-### v1.1.8-alpha.2
+### unreleased
 
-* REFACTOR: to use makara-builder@2
+* REFACTOR: to use makara-builder@2. See: https://github.com/krakenjs/makara-builder/blob/v2.x/README.md#api and https://github.com/krakenjs/makara-builder/blob/v2.x/CHANGELOG.md#v200
 
 ### v1.1.7 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.1.8-alpha.1
+
+* REFACTOR: to use makara-builder@2
+
 ### v1.1.7 
 
 * FIX: upgrade glob module to ^7 to address vulnerability in minimatch. https://github.com/jpillora/node-glob-all/issues/12

--- a/build.js
+++ b/build.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+var wrap = function (out) {
+	return 'define("_languagepack", function () { return ' + JSON.stringify(out) + '; });';
+};
+
+var writer = function (outputRoot, cb) {
+	return function (out) {
+		fs.writeFile(path.resolve(outputRoot, '_languagepack.js'), wrap(out), cb);
+	};
+};
+
+module.exports = function build(root, cb) {
+	require('makara-builder')(root, writer, cb);
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
 var mlpp = require('makara-languagepackpath');
-var writer = require('makara-writer-amd');
+
 module.exports = {
     build: function (root, cb) {
-        require('makara-builder')(root, writer, cb);
+        require('./build')(root, cb);
     },
     languagePackPath: function (locale) {
         // Require.js insists on adding .js to everything,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-amdify",
-  "version": "1.1.7",
+  "version": "1.1.8-alpha.1",
   "description": "Tools to make AMD content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
   "repository": "https://github.com/krakenjs/makara-amdify.git",
   "dependencies": {
     "async": "^0.9.0",
-    "glob": "^7.0.5",
-    "makara-builder": "^1.0.0",
-    "makara-languagepackpath": "^1.1.0",
-    "makara-writer-amd": "^1.0.0"
+    "makara-builder": "2.0.0-alpha.1",
+    "makara-languagepackpath": "^1.1.0"
   },
   "devDependencies": {
     "tape": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-amdify",
-  "version": "1.1.8-alpha.2",
+  "version": "1.1.7",
   "description": "Tools to make AMD content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",
@@ -10,7 +10,7 @@
   },
   "repository": "https://github.com/krakenjs/makara-amdify.git",
   "dependencies": {
-    "makara-builder": "2.0.0-alpha.1",
+    "makara-builder": "^2.0.0",
     "makara-languagepackpath": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makara-amdify",
-  "version": "1.1.8-alpha.1",
+  "version": "1.1.8-alpha.2",
   "description": "Tools to make AMD content bundles for krakenjs apps.",
   "main": "index.js",
   "author": "Aria Stewart <ariastewart@paypal.com>",
@@ -10,7 +10,6 @@
   },
   "repository": "https://github.com/krakenjs/makara-amdify.git",
   "dependencies": {
-    "async": "^0.9.0",
     "makara-builder": "2.0.0-alpha.1",
     "makara-languagepackpath": "^1.1.0"
   },


### PR DESCRIPTION
use makara-builder interface introduced here: https://github.com/krakenjs/makara-builder/pull/4

This pulls up the spundle and directory creation from the "writer" method and into makara-builder. Removes repeated code from this module and any other "makara-*" modules.
